### PR TITLE
flex box 실습

### DIFF
--- a/LEARN-HTML-CSS/flexbox/README.MD
+++ b/LEARN-HTML-CSS/flexbox/README.MD
@@ -1,0 +1,29 @@
+
+<h1> 1 . justify-content: space-betwwen; 이 row에서는 적용이 되지만 colume에서는 왜 안되는 것 인가. </h1>
+
+   <h2> 문제점: </h2>
+
+      .flex-container{
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-between;
+            background-color: antiquewhite;
+        }
+
+        위와 같은 css가 있다. 내부 요소를 세로로 배치 한 후 간격을 일정하게 조절하는건데 justify-content가 적용이 되지 않았다.
+
+   <h2> 해결 </h2>
+
+        height: 100vh; 를 추가해줌으로 해결이 되었다.
+
+   <h2> 생각해보자 </h2>
+
+        배경색을 입혀서 보니까 이해가 되었다. div같은 박스요소는 가로축으로는 쭉 공간을 차지하지만 세로축은 컨텐츠 길이 만큼 차지하는것이다.
+        
+        여기서 컨테이너를 브라우저의 현제 크기에 맞게 100vh 뷰포트를 주면 세로공간 만큼 컨테이너가 늘어나고 거기에 맞게 space-between이 되는것이다.
+
+        뷰포트를 적용하기전에는 늘어날 공간이 없기 때문에 space-between이 되지 않았던 것 이다.
+
+        꼭 뷰포트가 아니더라도 크키를 조정해주면 거기에 맞게 늘어난다.
+

--- a/LEARN-HTML-CSS/flexbox/index.html
+++ b/LEARN-HTML-CSS/flexbox/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <!-- <link rel="stylesheet" href="styleA.css"> -->
+    <style>
+
+        .flex-container{
+            display: flex;
+            justify-content: start;
+            height: 100vh;
+            width: 100vh;
+        }
+
+        .item{
+                
+            height: 150px;
+            min-height: 150px;
+            max-height: 150px;
+
+            width: 100px;
+            min-width: 100px;
+            max-width: 100px;
+
+
+            font-size: 40px;
+            margin-left: 10px;
+            background-color: #eeeff2;
+            
+            border-left: 10px dotted #D0D0FF;
+
+            padding-left: 10px;
+        }
+
+        .item:hover{
+            cursor: pointer;
+            background-color: yellow;
+            color: goldenrod;
+        }
+
+        .f{
+            position: fixed;
+            bottom: 0;
+            right: 0;  
+        }
+
+        .inner-item{
+            width: 10px;
+            height: 10px;
+            background-color: aqua;
+        }
+    </style>
+</head>
+<body>
+
+    <div class="flex-container">
+        <div class="item odd a">
+            A
+        </div>
+        <div class="item even b">
+            B
+        </div>
+        <div class="item odd c">
+            C
+        </div>
+        <div class="item even d">
+            D
+        </div>
+        <div class="item odd e">
+                E
+        </div>
+        <div class="item even f">
+                F
+        </div>
+      </div>
+    
+</body>
+</html>

--- a/LEARN-HTML-CSS/flexbox/styleA.css
+++ b/LEARN-HTML-CSS/flexbox/styleA.css
@@ -1,0 +1,37 @@
+.flex-container{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    height: 100vh;
+    
+}
+
+.item{
+    width: 100px;
+    height: 100px;
+
+    min-width: 100px;
+    min-height: 100px;
+
+    font-size: 40px;
+    text-align: center;
+    font-family: Tahoma;
+
+    border-top: 1px solid #687291;
+    
+}
+
+.odd{
+    background-color: #dfe1e7;
+}
+
+.even{
+    background-color: #eeeffe;
+}
+
+.f{
+    border: 4px solid black;
+    align-content: center;
+}
+    


### PR DESCRIPTION

<h1> 1 . justify-content: space-betwwen; 이 row에서는 적용이 되지만 colume에서는 왜 안되는 것 인가. </h1>

   <h2> 문제점: </h2>

      .flex-container{
            display: flex;
            flex-direction: column;
            align-items: center;
            justify-content: space-between;
            background-color: antiquewhite;
        }

        위와 같은 css가 있다. 내부 요소를 세로로 배치 한 후 간격을 일정하게 조절하는건데 justify-content가 적용이 되지 않았다.

   <h2> 해결 </h2>

        height: 100vh; 를 추가해줌으로 해결이 되었다.

   <h2> 생각해보자 </h2>

        배경색을 입혀서 보니까 이해가 되었다. div같은 박스요소는 가로축으로는 쭉 공간을 차지하지만 세로축은 컨텐츠 길이 만큼 차지하는것이다.
        
        여기서 컨테이너를 브라우저의 현제 크기에 맞게 100vh 뷰포트를 주면 세로공간 만큼 컨테이너가 늘어나고 거기에 맞게 space-between이 되는것이다.

        뷰포트를 적용하기전에는 늘어날 공간이 없기 때문에 space-between이 되지 않았던 것 이다.

        꼭 뷰포트가 아니더라도 크키를 조정해주면 거기에 맞게 늘어난다.

